### PR TITLE
Pin later version of PDFMiner for Copilot

### DIFF
--- a/requirements/python
+++ b/requirements/python
@@ -6,7 +6,7 @@ beautifulsoup4~=4.8.0
 chardet==3.*
 docx2txt~=0.8
 extract-msg<=0.29.6 #Last with python2 support
-pdfminer.six==20191110 #Last with python2 support
+pdfminer.six==20220524 #Last with python2 support
 python-pptx~=0.6.18
 six>=1.14.0
 SpeechRecognition~=3.8.1

--- a/requirements/python
+++ b/requirements/python
@@ -6,7 +6,7 @@ beautifulsoup4~=4.8.0
 chardet==3.*
 docx2txt~=0.8
 extract-msg<=0.29.6 #Last with python2 support
-pdfminer.six==20220524 #Last with python2 support
+pdfminer.six==20220524
 python-pptx~=0.6.18
 six>=1.14.0
 SpeechRecognition~=3.8.1


### PR DESCRIPTION
To move code from our older LLM repository to quorum-site, we need to install a dependency of `pdfminer.six`. 

Version `20220524` is the latest with python3.7 support, which includes some necessary methods that are not available with `20191110`.

Textract pins `20191110` because it is the last version that supporters python2, since we no longer need to support python2, we can upgrade Textract's dependency.

https://quorumanalytics.slack.com/archives/C05M93EK8TZ/p1740691520988629?thread_ts=1740689842.026769&cid=C05M93EK8TZ

https://github.com/QuorumUS/quorum-site/pull/45936